### PR TITLE
BackportAsyncImage behave like @StateObject

### DIFF
--- a/Sources/BackportAsyncImage/BackportAsyncImage.swift
+++ b/Sources/BackportAsyncImage/BackportAsyncImage.swift
@@ -88,6 +88,58 @@ private final class ViewModel: ObservableObject {
     }
 }
 
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+private struct ContentBody<Content: View>: View {
+    @StateObject private var viewModel: ViewModel
+    private let content: (AsyncImagePhase) -> Content
+
+    init(viewModel: ViewModel,
+         @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
+        self._viewModel = .init(wrappedValue: viewModel)
+        self.content = content
+        self.viewModel.download()
+    }
+
+    var body: some View {
+        content(viewModel.phase)
+    }
+}
+
+@available(iOS, deprecated: 14.0)
+@available(macOS, deprecated: 11.0)
+@available(tvOS, deprecated: 14.0)
+@available(watchOS, deprecated: 7.0)
+private struct ContentCompatBody<Content: View>: View {
+    struct Body: View {
+        @ObservedObject private var viewModel: ViewModel
+        private let content: (AsyncImagePhase) -> Content
+
+        init(viewModel: ViewModel,
+             @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
+            self.viewModel = viewModel
+            self.content = content
+            self.viewModel.download()
+        }
+
+        var body: some View {
+            content(viewModel.phase)
+        }
+    }
+
+    @State private var viewModel: ViewModel
+    private let content: (AsyncImagePhase) -> Content
+
+    init(viewModel: ViewModel,
+         @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
+        self.viewModel = viewModel
+        self.content = content
+    }
+
+    var body: Body {
+        Body(viewModel: viewModel, content: content)
+    }
+}
+
 struct BackportAsyncImage_Previews: PreviewProvider {
     static var url: URL? {
         URL(string: "http://httpbin.org/image/png")

--- a/Sources/BackportAsyncImage/BackportAsyncImage.swift
+++ b/Sources/BackportAsyncImage/BackportAsyncImage.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public struct BackportAsyncImage<Content: View>: View {
-    @ObservedObject private var viewModel: ViewModel
+    private let viewModel: ViewModel
     private let content: (AsyncImagePhase) -> Content
 
     public init(url: URL?, scale: CGFloat = 1) where Content == Image {
@@ -35,7 +35,11 @@ public struct BackportAsyncImage<Content: View>: View {
     }
 
     public var body: some View {
-        content(viewModel.phase)
+        if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+            ContentBody(viewModel: viewModel, content: content)
+        } else {
+            ContentCompatBody(viewModel: viewModel, content: content)
+        }
     }
 }
 


### PR DESCRIPTION
With this implementation, ContentView body will be redrawn each time a button is pressed.
Then, `@ObserbedObject` is also regenerated, and `AsyncImagePhase` revert to `empty`.

```swift
struct ContentView: View {
    @State var count: Int = 0

    var body: some View {
        VStack {
            AsyncImage(url: URL(string: "https://example.com/icon.png"))
            Button {
                count += 1
            } label: {
                Text("Count: \(count)")
            }
        }
    }
}
```

This issue can be avoided by changing `@ObserbedObject` to `@StateObject`.
However, `@StateObject` is not available on iOS 13/macOS 10.15/tvOS 13/watchOS 6, so resolved it using `@State`.

## References
- https://kouki.hatenadiary.com/entry/2021/06/22/130000
- https://github.com/ra1028/SwiftUI-Hooks/blob/main/Sources/Hooks/HookScope.swift